### PR TITLE
Add Event List and Event Summary API

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,6 +1,9 @@
 package intercom
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // EventService handles interactions with the API through an EventRepository.
 type EventService struct {
@@ -9,17 +12,74 @@ type EventService struct {
 
 // An Event represents a new event that happens to a User.
 type Event struct {
-	ID        string                 `json:"id,omitempty"`
-	Email     string                 `json:"email,omitempty"`
-	UserID    string                 `json:"user_id,omitempty"`
-	EventName string                 `json:"event_name,omitempty"`
-	CreatedAt int64                  `json:"created_at,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	ID             string                 `json:"id,omitempty"`
+	Email          string                 `json:"email,omitempty"`
+	UserID         string                 `json:"user_id,omitempty"`
+	IntercomUserID string                 `json:"intercom_user_id,omitempty"`
+	EventName      string                 `json:"event_name,omitempty"`
+	CreatedAt      int64                  `json:"created_at,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type EventPages struct {
+	Next string `json:"next,omitempty"`
+}
+
+type EventList struct {
+	Pages  EventPages `json:"pages,omitempty"`
+	Events []Event
+}
+
+type EventSummaries struct {
+	Email          string `json:"email,omitempty"`
+	UserID         string `json:"user_id,omitempty"`
+	IntercomUserID string `json:"intercom_user_id,omitempty"`
+	Events         []EventSummary
+}
+
+type EventSummary struct {
+	Name        string    `json:"name,omitempty"`
+	First       time.Time `json:"first,omitempty"`
+	Last        time.Time `json:"last,omitempty"`
+	Count       int       `json:"count,omitempty"`
+	Description string    `json:"description,omitempty"`
+}
+
+type eventParams struct {
+	Type           string `url:"type,omitempty"`
+	UserID         string `url:"user_id,omitempty"`
+	Email          string `url:"email,omitempty"`
+	IntercomUserID string `url:"intercom_user_id,omitempty"`
+	Summary        bool   `url:"summary,omitempty"`
 }
 
 // Save a new Event
 func (e *EventService) Save(event *Event) error {
 	return e.Repository.save(event)
+}
+
+func (e *EventService) ListByID(id string) (EventList, error) {
+	return e.Repository.list(eventParams{IntercomUserID: id})
+}
+
+func (e *EventService) ListByUserID(userID string) (EventList, error) {
+	return e.Repository.list(eventParams{UserID: userID})
+}
+
+func (e *EventService) ListByEmail(email string) (EventList, error) {
+	return e.Repository.list(eventParams{Email: email})
+}
+
+func (e *EventService) SummaryByID(id string) (EventSummaries, error) {
+	return e.Repository.summary(eventParams{IntercomUserID: id, Summary: true})
+}
+
+func (e *EventService) SummaryByUserID(userID string) (EventSummaries, error) {
+	return e.Repository.summary(eventParams{UserID: userID, Summary: true})
+}
+
+func (e *EventService) SummaryByEmail(email string) (EventSummaries, error) {
+	return e.Repository.summary(eventParams{Email: email, Summary: true})
 }
 
 func (e Event) String() string {

--- a/event_api.go
+++ b/event_api.go
@@ -1,10 +1,15 @@
 package intercom
 
-import "gopkg.in/intercom/intercom-go.v2/interfaces"
+import (
+	"encoding/json"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
+)
 
 // EventRepository defines the interface for working with Events through the API.
 type EventRepository interface {
 	save(*Event) error
+	list(params eventParams) (EventList, error)
+	summary(params eventParams) (EventSummaries, error)
 }
 
 // EventAPI implements EventRepository
@@ -15,4 +20,33 @@ type EventAPI struct {
 func (api EventAPI) save(event *Event) error {
 	_, err := api.httpClient.Post("/events", event)
 	return err
+}
+
+func (api EventAPI) list(params eventParams) (EventList, error) {
+	eventList := EventList{}
+	data, err := api.listEvents(params)
+	if err != nil {
+		return eventList, err
+	}
+	err = json.Unmarshal(data, &eventList)
+	return eventList, err
+}
+
+func (api EventAPI) summary(params eventParams) (EventSummaries, error) {
+	eventSummaries := EventSummaries{}
+	data, err := api.listEvents(params)
+	if err != nil {
+		return eventSummaries, err
+	}
+	err = json.Unmarshal(data, &eventSummaries)
+	return eventSummaries, err
+}
+
+func (api EventAPI) listEvents(params eventParams) ([]byte, error) {
+	params.Type = "user"
+	data, err := api.httpClient.Get("/events", params)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/event_api_test.go
+++ b/event_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -24,9 +25,64 @@ func TestEventAPISaveFail(t *testing.T) {
 	}
 }
 
+func TestEventAPIList(t *testing.T) {
+	http := TestEventHTTPClient{t: t, expectedURI: "/events", fixtureFilename: "fixtures/event_list.json"}
+	api := EventAPI{httpClient: &http}
+	params := eventParams{UserID: "444"}
+	eventList, _ := api.list(params)
+	if len(eventList.Events) != 2 {
+		t.Errorf("Error retrieving event list")
+	}
+	if eventList.Events[0].ID != "1234" {
+		t.Errorf("Incorrect EventID")
+	}
+	if eventList.Events[1].ID != "5678" {
+		t.Errorf("Incorrect EventID")
+	}
+}
+
+func TestEventAPIListFail(t *testing.T) {
+	http := TestEventHTTPClient{t: t, expectedURI: "/events", shouldFail: true}
+	api := EventAPI{httpClient: &http}
+	params := eventParams{UserID: "444"}
+	_, err := api.list(params)
+	if herr, ok := err.(interfaces.HTTPError); ok && herr.Code != "not_found" {
+		t.Errorf("Error not returned")
+	}
+}
+
+func TestEventAPISummary(t *testing.T) {
+	http := TestEventHTTPClient{t: t, expectedURI: "/events", fixtureFilename: "fixtures/event_summaries.json"}
+	api := EventAPI{httpClient: &http}
+	params := eventParams{UserID: "444"}
+	eventList, _ := api.summary(params)
+	if len(eventList.Events) != 2 {
+		t.Errorf("Error retrieving event list")
+	}
+	if eventList.Events[0].Count != 1234 {
+		t.Errorf("Incorrect Count")
+	}
+	if eventList.Events[1].Count != 5678 {
+		t.Errorf("Incorrect Count")
+	}
+}
+
+func TestEventAPISummaryFail(t *testing.T) {
+	http := TestEventHTTPClient{t: t, expectedURI: "/events", shouldFail: true}
+	api := EventAPI{httpClient: &http}
+	params := eventParams{UserID: "444"}
+	_, err := api.summary(params)
+	if herr, ok := err.(interfaces.HTTPError); ok && herr.Code != "not_found" {
+		t.Errorf("Error not returned")
+	}
+}
+
 type TestEventHTTPClient struct {
 	TestHTTPClient
-	t           *testing.T
+	t *testing.T
+
+	fixtureFilename string
+
 	expectedURI string
 	shouldFail  bool
 }
@@ -40,4 +96,15 @@ func (t TestEventHTTPClient) Post(uri string, event interface{}) ([]byte, error)
 		return nil, err
 	}
 	return nil, nil
+}
+
+func (t TestEventHTTPClient) Get(uri string, event interface{}) ([]byte, error) {
+	if uri != "/events" {
+		t.t.Errorf("Wrong endpoint called")
+	}
+	if t.shouldFail {
+		err := interfaces.HTTPError{StatusCode: 404, Code: "not_found", Message: "User Not Found"}
+		return nil, err
+	}
+	return ioutil.ReadFile(t.fixtureFilename)
 }

--- a/event_test.go
+++ b/event_test.go
@@ -41,11 +41,76 @@ func successBody(t *testing.T, event Event) error {
 	return nil
 }
 
+func TestEventList(t *testing.T) {
+	eventList, _ := (&EventService{Repository: TestEventAPI{t: t, eventList: eventListSuccess}}).ListByUserID("1")
+	if eventList.Events[0].UserID != "1" {
+		t.Errorf("no events for user id found")
+	}
+	eventList, _ = (&EventService{Repository: TestEventAPI{t: t, eventList: eventListSuccess}}).ListByEmail("2")
+	if eventList.Events[0].Email != "2" {
+		t.Errorf("no events for email found")
+	}
+	eventList, _ = (&EventService{Repository: TestEventAPI{t: t, eventList: eventListSuccess}}).ListByID("3")
+	if eventList.Events[0].IntercomUserID != "3" {
+		t.Errorf("no events for Intercom user id found")
+	}
+
+	_, err := (&EventService{Repository: TestEventAPI{t: t, eventList: eventListFail}}).ListByID("3")
+	if err.Error() != "event list fail" {
+		t.Errorf("error not propagated")
+	}
+}
+
+func eventListSuccess(params eventParams) (EventList, error) {
+	return EventList{Events: []Event{{UserID: params.UserID, IntercomUserID: params.IntercomUserID, Email: params.Email}}}, nil
+}
+
+func eventListFail(_ eventParams) (EventList, error) {
+	return EventList{}, errors.New("event list fail")
+}
+
+func TestEventSummary(t *testing.T) {
+	eventSummary, _ := (&EventService{Repository: TestEventAPI{t: t, eventSummary: eventSummarySuccess}}).SummaryByUserID("1")
+	if eventSummary.UserID != "1" {
+		t.Errorf("no events for user id found")
+	}
+	eventSummary, _ = (&EventService{Repository: TestEventAPI{t: t, eventSummary: eventSummarySuccess}}).SummaryByEmail("2")
+	if eventSummary.Email != "2" {
+		t.Errorf("no events for email found")
+	}
+	eventSummary, _ = (&EventService{Repository: TestEventAPI{t: t, eventSummary: eventSummarySuccess}}).SummaryByID("3")
+	if eventSummary.IntercomUserID != "3" {
+		t.Errorf("no events for Intercom user id found")
+	}
+
+	_, err := (&EventService{Repository: TestEventAPI{t: t, eventSummary: eventSummaryFail}}).SummaryByID("3")
+	if err.Error() != "event summary fail" {
+		t.Errorf("error not propagated")
+	}
+}
+
+func eventSummarySuccess(params eventParams) (EventSummaries, error) {
+	return EventSummaries{UserID: params.UserID, IntercomUserID: params.IntercomUserID, Email: params.Email}, nil
+}
+
+func eventSummaryFail(_ eventParams) (EventSummaries, error) {
+	return EventSummaries{}, errors.New("event summary fail")
+}
+
 type TestEventAPI struct {
-	t    *testing.T
-	body func(*testing.T, Event) error
+	t            *testing.T
+	body         func(*testing.T, Event) error
+	eventList    func(eventParams) (EventList, error)
+	eventSummary func(eventParams) (EventSummaries, error)
 }
 
 func (t TestEventAPI) save(event *Event) error {
 	return t.body(t.t, *event)
+}
+
+func (t TestEventAPI) list(params eventParams) (EventList, error) {
+	return t.eventList(params)
+}
+func (t TestEventAPI) summary(params eventParams) (EventSummaries, error) {
+	return t.eventSummary(params)
 }

--- a/fixtures/event_list.json
+++ b/fixtures/event_list.json
@@ -1,0 +1,13 @@
+{
+  "type": "event.list",
+  "events": [
+    {
+      "type": "event",
+      "id": "1234"
+    },
+    {
+      "type": "event",
+      "id": "5678"
+    }
+  ]
+}

--- a/fixtures/event_summaries.json
+++ b/fixtures/event_summaries.json
@@ -1,0 +1,11 @@
+{
+  "type": "event.list",
+  "events": [
+    {
+      "count": 1234
+    },
+    {
+      "count": 5678
+    }
+  ]
+}


### PR DESCRIPTION
#### Why?
Implements the List Events & Event Summaries API from https://developers.intercom.com/intercom-api-reference/reference#list-user-events

#### How?
Creates additional structs representing the event list data model.
Adds to the existing event.go and event_api.go files, using the existing instance of `interfaces.HTTPClient`.

